### PR TITLE
[✨ Feature] 모바일버전 중복처리, userdata store저장

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.66.9",
         "@types/styled-components": "^5.1.34",
         "axios": "^1.8.1",
+        "framer-motion": "^12.5.0",
         "query-string": "^9.1.1",
         "react": "^19.0.0",
         "react-device-detect": "^2.2.3",
@@ -2539,6 +2540,32 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.5.0.tgz",
+      "integrity": "sha512-buPlioFbH9/W7rDzYh1C09AuZHAk2D1xTA1BlounJ2Rb9aRg84OXexP0GLd+R83v0khURdMX7b5MKnGTaSg5iA==",
+      "dependencies": {
+        "motion-dom": "^12.5.0",
+        "motion-utils": "^12.5.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3052,6 +3079,19 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.5.0.tgz",
+      "integrity": "sha512-uH2PETDh7m+Hjd1UQQ56yHqwn83SAwNjimNPE/kC+Kds0t4Yh7+29rfo5wezVFpPOv57U4IuWved5d1x0kNhbQ==",
+      "dependencies": {
+        "motion-utils": "^12.5.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.5.0.tgz",
+      "integrity": "sha512-+hFFzvimn0sBMP9iPxBa9OtRX35ZQ3py0UHnb8U29VD+d8lQ8zH3dTygJWqK7av2v6yhg7scj9iZuvTS0f4+SA=="
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-query": "^5.66.9",
     "@types/styled-components": "^5.1.34",
     "axios": "^1.8.1",
+    "framer-motion": "^12.5.0",
     "query-string": "^9.1.1",
     "react": "^19.0.0",
     "react-device-detect": "^2.2.3",

--- a/public/Icon/ArrowIcon.tsx
+++ b/public/Icon/ArrowIcon.tsx
@@ -1,8 +1,13 @@
 // < 이 아이콘
-const ArrowIcon = ({ strokeColor = '#DADFE7' }) => {
+interface ArrowIconProps {
+  strokeColor?: string;
+  className?: string;
+}
+
+const ArrowIcon = ({ strokeColor = '#DADFE7', className }: ArrowIconProps) => {
   return (
     <svg
-      xmlns="http://www.w3.org/2000/svg"
+      className={className}
       width="24"
       height="24"
       viewBox="0 0 24 24"

--- a/public/Icon/MobileCamera.tsx
+++ b/public/Icon/MobileCamera.tsx
@@ -1,0 +1,38 @@
+const MobileCamera = () => {
+  return (
+    <svg
+      width="61"
+      height="65"
+      viewBox="0 0 61 65"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M37.5 36L2.5 36C1.39543 36 0.5 35.1046 0.5 34L0.5 11.6667L11.3333 -9.4708e-07L37.5 -3.23464e-06C38.6046 -3.33121e-06 39.5 0.895428 39.5 2L39.5 34C39.5 35.1046 38.6046 36 37.5 36Z"
+        fill="#C3EAD2"
+      />
+      <path
+        d="M10.3333 11.6665L0.500001 11.6665L11.3333 -0.000163072L11.3333 10.6665C11.3333 11.2188 10.8856 11.6665 10.3333 11.6665Z"
+        fill="#70D09A"
+      />
+      <rect x="26.5" y="9" width="34" height="56" rx="5" fill="#1ABA6E" />
+      <rect x="28.5" y="9" width="32" height="56" rx="5" fill="#70D09A" />
+      <rect x="31.5" y="12" width="26" height="50" rx="3" fill="#E6F7ED" />
+      <rect x="37.5" y="10" width="14" height="4" rx="2" fill="#70D09A" />
+      <path
+        d="M44.499 34L44.499 39.9987"
+        stroke="#70D09A"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+      <path
+        d="M47.499 36.999L41.5003 36.999"
+        stroke="#70D09A"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+};
+
+export default MobileCamera;

--- a/public/Icon/MobileUpload.tsx
+++ b/public/Icon/MobileUpload.tsx
@@ -1,0 +1,26 @@
+const MobileUpload = () => {
+  return (
+    <svg
+      width="62"
+      height="59"
+      viewBox="0 0 62 59"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect y="16" width="62" height="30" rx="3" fill="#00874A" />
+      <rect x="14" y="5" width="38" height="51" rx="2" fill="#70D09A" />
+      <rect x="12" y="2" width="38" height="51" rx="2" fill="#9CDDB6" />
+      <rect x="10" width="38" height="51" rx="2" fill="#C3EAD2" />
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M3 16C1.34315 16 0 17.3431 0 19V25V47V57C0 58.1046 0.895432 59 2 59H60C61.1046 59 62 58.1046 62 57V25C62 23.8954 61.1046 23 60 23H25.8824L23.765 17.8578C23.3021 16.7336 22.2066 16 20.9909 16H3Z"
+        fill="#70D09A"
+      />
+      <rect x="15" y="5" width="28" height="2" rx="1" fill="#9CDDB6" />
+      <rect x="15" y="9" width="28" height="2" rx="1" fill="#9CDDB6" />
+    </svg>
+  );
+};
+
+export default MobileUpload;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ const App = () => {
   }, []);
 
   if (isMobileView === null) {
-    return <p>로딩 중...</p>;
+    return <p></p>;
   }
 
   return <RouterProvider router={isMobileView ? MobileRouter : WebRouter} />;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,9 +8,17 @@ const App = () => {
   const [isMobileView, setIsMobileView] = useState<boolean | null>(null);
 
   useEffect(() => {
-    setIsMobileView(isMobile);
-  }, []);
+    const updateView = () => {
+      setIsMobileView(isMobile);
+    };
 
+    updateView();
+    window.addEventListener('resize', updateView); // 화면 크기 변경 감지
+
+    return () => {
+      window.removeEventListener('resize', updateView);
+    };
+  }, []);
   if (isMobileView === null) {
     return <p></p>;
   }

--- a/src/common/SideModal/SideModal.tsx
+++ b/src/common/SideModal/SideModal.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import axios from 'axios'; // Axios 사용
 import ArrowIcon from '../../../public/Icon/ArrowIcon';
 import LogoutIcon from '../../../public/Icon/LogoutIcon';
 import EditIcon from '../../../public/Icon/EditIcon';
@@ -50,10 +49,10 @@ const SideModal = ({ isOpen, onClose, role }: SideModalProps) => {
       if (response.data.isSuccess) {
         const userData = response.data.result;
         console.log(userData);
-        setUserId(userData.userId);
+        setUserId(userData.loginId);
         setName(userData.name);
         setTeamName(userData.teamName || '');
-        setEmail(userData.email || ''); 
+        setEmail(userData.email || '');
         setPhone(userData.phone || '');
         setSelectedBank(userData.bank || '');
         setAccountNumber(userData.account || '');
@@ -66,14 +65,18 @@ const SideModal = ({ isOpen, onClose, role }: SideModalProps) => {
   const handleUpdate = async () => {
     try {
       const updatedData = {
-        loginId: userId,
-        email,
-        phone,
-        bank: selectedBank,
-        account: accountNumber
+        loginId: userId || '', 
+        email: email || '',
+        phone: phone || '',
+        bank: selectedBank || '',
+        account: accountNumber || ''
       };
-
-      await api.put('/user/update', updatedData);
+      console.log('📩 업데이트 요청 데이터:', updatedData);
+      await api.put('/user/update', updatedData, {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
       setIsEditing(false);
     } catch (error) {
       console.error('사용자 정보 업데이트 중 오류 발생:', error);
@@ -140,7 +143,8 @@ const SideModal = ({ isOpen, onClose, role }: SideModalProps) => {
           <div
             className={`flex gap-1 ${role === 'CS' ? 'flex-col' : 'flex-row'} `}
           >
-            <div className="text-gray-800 font-xl-bold ">김구름 </div>
+            <div className="text-gray-800 font-xl-bold ">{name}</div>
+
             {role === 'admin' && (
               <span className="flex gap-[8px] px-[10px] py-[2px] justify-center items-center rounded-3xl bg-primary-50 text-primary-600 font-xs-semibold">
                 관리자
@@ -153,7 +157,7 @@ const SideModal = ({ isOpen, onClose, role }: SideModalProps) => {
             )}
             {role === 'CS' && (
               <div className="text-gray-500 font-md-regular mt-[4px]">
-                서울우유태평고객센터
+                {teamName}
               </div>
             )}
           </div>

--- a/src/common/Sidebar.tsx
+++ b/src/common/Sidebar.tsx
@@ -12,12 +12,16 @@ import {
   HQMenuItems
 } from '../routes/SidebarRouter';
 import SidebarUploadButton from '../pages/CS/TaxUpload/SidebarUploadBtn';
+import { useAuthStore } from '../store/useAuthStore';
 
 interface RoleProps {
   type: 'admin' | 'HQ' | 'CS';
 }
 
 const Sidebar = ({ type }: RoleProps) => {
+  const { user } = useAuthStore();
+  console.log('Zustand 상태:', { user });
+
   const navigate = useNavigate();
   const location = useLocation();
   const [selectedMenu, setSelectedMenu] = useState<string>('홈');
@@ -84,7 +88,8 @@ const Sidebar = ({ type }: RoleProps) => {
             className={`flex gap-1 ${type === 'CS' ? 'flex-col' : 'flex-row'}`}
           >
             <div className="text-gray-800 font-xl-bold">
-              김구름 <span className="text-gray-800 font-xl-regular">님</span>
+              {user?.name}{' '}
+              <span className="text-gray-800 font-xl-regular">님</span>
             </div>
 
             {type === 'admin' && (
@@ -99,7 +104,7 @@ const Sidebar = ({ type }: RoleProps) => {
             )}
             {type === 'CS' && (
               <div className="text-gray-500 font-md-regular mt-[4px]">
-                서울우유태평고객센터
+                {user?.teamName}
               </div>
             )}
           </div>

--- a/src/common/StatusBagde.tsx
+++ b/src/common/StatusBagde.tsx
@@ -2,7 +2,7 @@ const statusStyles = {
   반영: 'bg-primary-50 text-primary-600 ',
   미반영: 'bg-gray-200 text-gray-500',
   승인됨: 'bg-primary-50 text-primary-600 ',
-  반려됨: 'bg-gray-200 text-gray-500'
+  반려됨: 'bg-warning-50 text-warning-700'
 };
 
 export type Status = '승인됨' | '반려됨' | '반영' | '미반영';

--- a/src/common/TaxDetailModal.tsx
+++ b/src/common/TaxDetailModal.tsx
@@ -130,7 +130,7 @@ const TaxDetailModal = ({
           currentSearchParams ? `?${currentSearchParams}` : ''
         }`;
 
-        navigate(`/upload-tax/step1?taxId=${selectedItem?.id}`, {
+        navigate(`/cs/upload-tax/step1?taxId=${selectedItem?.id}`, {
           state: {
             selectedImage: imageUrl,
             returnUrl: returnUrl
@@ -148,7 +148,7 @@ const TaxDetailModal = ({
 
     const taxId = selectedItem.id || detailData?.issueId;
 
-    navigate(`/cs-tax/edit?taxId=${taxId}`, {
+    navigate(`/cs/tax/edit?taxId=${taxId}`, {
       state: {
         taxId,
         ...selectedItem,
@@ -220,10 +220,7 @@ const TaxDetailModal = ({
 
             <div>
               <h2 className="flex text-center font-xl-semibold text-gray-800 mt-[12px]">
-                {detailData?.title ||
-                  `${selectedItem.team}_${selectedItem.taxDate
-                    .replace(/\./g, '_')
-                    .replace(/^(\d{4})_(\d{2})_(\d{2})$/, '$1년_$2월_$3일')}`}
+                {detailData?.title}
               </h2>
 
               <div

--- a/src/common/UserSideModal.tsx
+++ b/src/common/UserSideModal.tsx
@@ -67,15 +67,7 @@ function UserSideModal() {
           </div>
         </div>
       )}
-      {/* {isConfirmOpen && (
-        <ConfirmModal
-          onClose={() => setIsConfirmOpen(false)}
-          onDelete={() => {
-            setIsConfirmOpen(false);
-            setIsOpen(false);
-          }}
-        />
-      )} */}
+      
       {isConfirmOpen && (
         <ConfirmModal
           isOpen={isConfirmOpen}

--- a/src/index.css
+++ b/src/index.css
@@ -35,3 +35,12 @@ textarea:focus {
   outline: none;
   box-shadow: none;
 }
+
+/* svg 애니메이션 비활성화 */
+.stop-animation {
+  animation: none !important;
+}
+
+.stop-animation * {
+  animation: none !important;
+}

--- a/src/pages/CS/TaxUpload/DuplicateTaxModal.tsx
+++ b/src/pages/CS/TaxUpload/DuplicateTaxModal.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import WarningIcon from '../../../../public/Icon/WarningIcon';
+import { isMobile } from 'react-device-detect';
 
 interface DuplicateTaxModalProps {
   title: string;
@@ -15,14 +16,16 @@ const DuplicateTaxModal = ({
   onClose
 }: DuplicateTaxModalProps) => {
   const navigate = useNavigate();
-
   const handleConfirm = () => {
     if (id) {
-      navigate(`/cs-tax?taxId=${id}`);
+      if (isMobile) {
+        navigate('/cs');
+      } else {
+        navigate(`/cs-tax?taxId=${id}`);
+      }
     }
     onClose();
   };
-
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30 z-50">
       <div className="w-[328px] bg-white rounded-[20px] drop-shadow-elevation2 flex flex-col">

--- a/src/pages/CS/TaxUpload/SidebarUploadBtn.tsx
+++ b/src/pages/CS/TaxUpload/SidebarUploadBtn.tsx
@@ -17,7 +17,7 @@ const SidebarUploadButton = () => {
 
       reader.readAsDataURL(file);
       reader.onload = () => {
-        navigate('/upload-tax/step1', {
+        navigate('/cs/upload-tax/step1', {
           state: { selectedImage: reader.result }
         });
       };
@@ -39,7 +39,7 @@ const SidebarUploadButton = () => {
         accept="image/*"
         ref={fileInputRef}
         style={{ display: 'none' }}
-        onChange={handleFileChange} 
+        onChange={handleFileChange}
       />
     </div>
   );

--- a/src/pages/CS/TaxUpload/Step1.tsx
+++ b/src/pages/CS/TaxUpload/Step1.tsx
@@ -79,7 +79,7 @@ const Step1 = () => {
           console.log('삭제완료후 재요청 ocr 응답:', res.data.result);
 
           // 4. 새로운 ID로 Step2 이동
-          navigate(`/upload-tax/step2?taxId=${ntsTaxId}`, {
+          navigate(`/cs/upload-tax/step2?taxId=${ntsTaxId}`, {
             state: { ocrData: res.data, selectedImage: croppedImage }
           });
           return;

--- a/src/pages/CS/TaxUpload/Step3.tsx
+++ b/src/pages/CS/TaxUpload/Step3.tsx
@@ -15,9 +15,9 @@ const Step3 = () => {
     if (!taxId) {
       return;
     }
-    
+
     const timer = setTimeout(() => {
-      navigate(`/cs-tax?taxId=${taxId}`);
+      navigate(`/cs/tax?taxId=${taxId}`);
     }, 3000);
 
     return () => clearTimeout(timer);

--- a/src/pages/CS/tax/EditTax.tsx
+++ b/src/pages/CS/tax/EditTax.tsx
@@ -102,7 +102,7 @@ const EditTax = () => {
       console.log('검증 API 응답:', validateResponse.data);
 
       if (validateResponse.data.isSuccess) {
-        navigate(`/upload-tax/step3?taxId=${taxId}`, {
+        navigate(`/cs/upload-tax/step3?taxId=${taxId}`, {
           state: { validationData: validateResponse.data.result }
         });
       } else {

--- a/src/pages/HQ/payment/Payment.tsx
+++ b/src/pages/HQ/payment/Payment.tsx
@@ -3,7 +3,6 @@ import SearchIcon from '../../../../public/Icon/SearchIcon';
 import PaymentGray from '../../../../public/Icon/PaymentIcon';
 import Button from '../../../common/Button';
 import Header from '../../../common/Header';
-import SelectCalendar from '../../../common/SelectCalendar';
 import SelectMonth from '../../../common/SelectMonth';
 import PaymentChart from './components/PaymentChart';
 

--- a/src/pages/HQ/payment/components/PaymentChart.tsx
+++ b/src/pages/HQ/payment/components/PaymentChart.tsx
@@ -21,7 +21,7 @@ const PaymentChart = () => {
           `/hq/payment-resolution/list?page=${page}&size=${size}`
         );
         if (response.data.isSuccess) {
-          setData(response.data.result);
+          setData(response.data.result.results || []);
         } else {
           setError('데이터를 불러오는 중 오류가 발생했습니다.');
         }

--- a/src/pages/HQ/payment/components/PaymentChart.tsx
+++ b/src/pages/HQ/payment/components/PaymentChart.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import PaymentChartHeader from './PaymentChartHeader';
-import ChartPagination from '../../../../common/ChartPagination';
 import PaymentChartContent from './PaymentContent';
 import api from '../../../../hooks/api';
 

--- a/src/pages/HQ/payment/components/PaymentContent.tsx
+++ b/src/pages/HQ/payment/components/PaymentContent.tsx
@@ -13,7 +13,7 @@ interface Props {
   data: PaymentData[];
 }
 
-const PaymentChartContent = ({ data }: Props) => {
+const PaymentChartContent = ({ data = [] }: Props) => {
   const navigate = useNavigate();
   return (
     <div className="w-full h-[584px] overflow-y-scroll custom-scrollbar">
@@ -22,7 +22,7 @@ const PaymentChartContent = ({ data }: Props) => {
           key={item.paymentResolutionId}
           className="mx-[8px] flex w-[960px] h-[42px] items-center rounded-[12px] hover:bg-gray-100 font-sm-medium"
           onClick={() =>
-            navigate(`/payment/detail/${item.paymentResolutionId}`)
+            navigate(`/hq/payment/detail/${item.paymentResolutionId}`)
           }
         >
           <div className="w-[350px] pl-5 text-sm font-medium text-gray-700 truncate">

--- a/src/pages/MOBILE/Home.tsx
+++ b/src/pages/MOBILE/Home.tsx
@@ -1,5 +1,12 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import MobileUpload from '../../../public/Icon/MobileUpload';
+import MobileCamera from '../../../public/Icon/MobileCamera';
+import SettingIcon from '../../../public/Icon/SettingIcon';
+import LogoGray from '../../../public/Icon/LogoGray';
+import TaxIconGray from '../../../public/Icon/TaxIconGray';
+import SpeakerGray from '../../../public/Icon/SpeakerGray';
+import ArrowIcon from '../../../public/Icon/ArrowIcon';
 
 const Home = () => {
   const navigate = useNavigate();
@@ -20,18 +27,73 @@ const Home = () => {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen ">
-      <h1>세금계산서 업로드 홈</h1>
+    <div className="min-h-screen bg-gray-50 flex flex-col px-5 py-10">
+      <header className="flex items-center justify-between py-4 mb-[18px]">
+        <LogoGray />
+        <button className="p-1 text-gray-400">
+          <SettingIcon />
+        </button>
+      </header>
 
-      <label className="bg-green-500 text-white px-6 py-3 ">
-        사진 업로드
-        <input
-          type="file"
-          accept="image/*"
-          className="hidden"
-          onChange={handleFileChange}
-        />
-      </label>
+      <section className="mt-6 mb-4 ">
+        <h1 className="font-md-bold text-gray-800 pb-1">김구름 님</h1>
+        <p className="font-sm-regular text-gray-500">서울우유태평고객센터</p>
+      </section>
+
+      <div className="flex gap-3 mb-6 justify-center">
+        <label className="w-[169px] h-[138px] py-3 pl-4 bg-primary-700 rounded-xl flex flex-col justify-between aspect-square cursor-pointer">
+          <input
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+          <div className="text-white font-md-semibold">
+            세금계산서 <br />
+            업로드
+          </div>
+          <div className="self-end mb-4 right-0">
+            <MobileUpload />
+          </div>
+        </label>
+
+        <button
+          className="w-[169px] h-[138px] py-3 pl-4 bg-primary-50 text-primary-600 rounded-xl flex flex-col justify-between aspect-square cursor-pointer"
+          onClick={() => navigate('/camera')}
+        >
+          <div className="text-left font-md-semibold">
+            세금계산서 <br />
+            촬영
+          </div>
+          <div className="self-end pb-4">
+            <MobileCamera />
+          </div>
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        <button
+          className="w-[353px] flex font-md-medium items-center justify-between p-4 bg-gray-100 rounded-[12px] text-gray-600"
+          disabled
+        >
+          <div className="flex items-center gap-2">
+            <TaxIconGray />
+            <span className="font-md-medium">세금계산서 조회</span>
+          </div>
+          <ArrowIcon strokeColor="#6C727E" className="rotate-180" />
+        </button>
+
+        <button
+          className="w-[353px] flex font-md-medium items-center justify-between p-4 bg-gray-100 rounded-[12px] text-gray-600"
+          disabled
+        >
+          <div className="flex items-center gap-2">
+            <SpeakerGray />
+            <span className="font-md-medium">공지사항</span>
+          </div>
+          <ArrowIcon strokeColor="#6C727E" className="rotate-180" />
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/pages/MOBILE/Home.tsx
+++ b/src/pages/MOBILE/Home.tsx
@@ -7,8 +7,11 @@ import LogoGray from '../../../public/Icon/LogoGray';
 import TaxIconGray from '../../../public/Icon/TaxIconGray';
 import SpeakerGray from '../../../public/Icon/SpeakerGray';
 import ArrowIcon from '../../../public/Icon/ArrowIcon';
+import { useAuthStore } from '../../store/useAuthStore';
 
 const Home = () => {
+  const { user } = useAuthStore();
+  console.log('Zustand 상태:', { user });
   const navigate = useNavigate();
   const [_, setSelectedImage] = useState<string | null>(null);
 
@@ -36,8 +39,8 @@ const Home = () => {
       </header>
 
       <section className="mt-6 mb-4 ">
-        <h1 className="font-md-bold text-gray-800 pb-1">김구름 님</h1>
-        <p className="font-sm-regular text-gray-500">서울우유태평고객센터</p>
+        <h1 className="font-md-bold text-gray-800 pb-1">{user?.name}님</h1>
+        <p className="font-sm-regular text-gray-500">{user?.teamName}</p>
       </section>
 
       <div className="flex gap-3 mb-6 justify-center">

--- a/src/pages/MOBILE/uploadTax/Complete.tsx
+++ b/src/pages/MOBILE/uploadTax/Complete.tsx
@@ -1,12 +1,18 @@
 import Button from '../../../common/Button';
 import CompleteCheck from '../../../../public/Icon/CompleteCheck';
 import { useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
 
 function Complete() {
   const navigate = useNavigate();
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-white px-4 py-6">
+    <motion.div
+      initial={{ y: 50, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      transition={{ duration: 0.8, ease: 'easeOut' }}
+      className="flex flex-col items-center justify-center min-h-screen bg-white px-4 py-6"
+    >
       <div className="w-full max-w-[360px] flex flex-col items-center px-5">
         <div className="w-[64px] h-[64px] rounded-full bg-primary-700 flex items-center justify-center mb-4">
           <CompleteCheck />
@@ -21,22 +27,17 @@ function Complete() {
           </p>
         </div>
 
-        <div className="w-full grid grid-cols-2 mt-auto rounded-[12px] gap-[16px]">
+        <div className="w-full flex mt-auto rounded-[12px] text-center justify-center">
           <Button
-            className="w-[152px] border border-gray-400 h-12 font-xl-semibold  text-gray-500"
-            onClick={() => navigate('/home')}
-          >
-            목록
-          </Button>
-          <Button
-            className="w-[152px] h-12 font-xl-semibold bg-primary-700 text-white "
+            className="w-[160px] h-[56px] font-xl-semibold bg-white border border-primary-700 text-primary-600"
             onClick={() => navigate('/home')}
           >
             추가 업로드
           </Button>
         </div>
       </div>
-    </div>
+    </motion.div>
   );
 }
+
 export default Complete;

--- a/src/pages/MOBILE/uploadTax/Complete.tsx
+++ b/src/pages/MOBILE/uploadTax/Complete.tsx
@@ -30,7 +30,7 @@ function Complete() {
         <div className="w-full flex mt-auto rounded-[12px] text-center justify-center">
           <Button
             className="w-[160px] h-[56px] font-xl-semibold bg-white border border-primary-700 text-primary-600"
-            onClick={() => navigate('/home')}
+            onClick={() => navigate('/cs')}
           >
             추가 업로드
           </Button>

--- a/src/pages/MOBILE/uploadTax/ImageCrop.tsx
+++ b/src/pages/MOBILE/uploadTax/ImageCrop.tsx
@@ -1,5 +1,7 @@
+'use client';
+
 import { useState, useRef, useEffect } from 'react';
-import ReactCrop, { Crop, PixelCrop } from 'react-image-crop';
+import ReactCrop, { type Crop, type PixelCrop } from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
 import Rotation1 from '../../../../public/Icon/Rotation1';
 import Rotation2 from '../../../../public/Icon/Rotation2';
@@ -9,10 +11,18 @@ import ResetIcon from '../../../../public/Icon/ResetIcon';
 interface ImageCropProps {
   initialImage?: string;
   onCropComplete: (croppedImg: string) => void;
+  onClose?: () => void;
+  onComplete?: () => void;
 }
 
-const ImageCrop = ({ initialImage }: ImageCropProps) => {
+const ImageCrop = ({
+  initialImage,
+  onCropComplete,
+  onClose,
+  onComplete
+}: ImageCropProps) => {
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [originalImage, setOriginalImage] = useState<string | null>(null);
   const [crop, setCrop] = useState<Crop>({
     unit: '%',
     width: 100,
@@ -20,104 +30,324 @@ const ImageCrop = ({ initialImage }: ImageCropProps) => {
     x: 0,
     y: 0
   });
-  const [_, setCompletedCrop] = useState<PixelCrop | null>(null);
+
+  // 최종적으로 선택된 크롭 정보
+  const [completedCrop, setCompletedCrop] = useState<PixelCrop | null>(null);
+
+  // 회전, 반전 상태
   const [rotation, setRotation] = useState(0);
   const [flipX, setFlipX] = useState(1);
   const [flipY, setFlipY] = useState(1);
-  const [aspectRatio, setAspectRatio] = useState(1);
+  const [imageSize, setImageSize] = useState({
+    width: 0,
+    height: 0,
+    naturalWidth: 0,
+    naturalHeight: 0
+  });
+  const [isImageLoaded, setIsImageLoaded] = useState(false);
   const imgRef = useRef<HTMLImageElement | null>(null);
   const cropContainerRef = useRef<HTMLDivElement | null>(null);
+  const previewCanvasRef = useRef<HTMLCanvasElement | null>(null);
 
+  // 이미지 초기 로드 시 원본 이미지 정보 설정
   useEffect(() => {
     if (initialImage) {
       setSelectedImage(initialImage);
+      setOriginalImage(initialImage);
+
       const img = new Image();
       img.onload = () => {
-        setAspectRatio(img.naturalWidth / img.naturalHeight);
+        setImageSize({
+          width: 0,
+          height: 0,
+          naturalWidth: img.width,
+          naturalHeight: img.height
+        });
+        setIsImageLoaded(true);
       };
       img.src = initialImage;
     }
   }, [initialImage]);
 
-  const handleRotateLeft = () => {
-    setRotation((prev) => (prev - 90) % 360);
-    setAspectRatio((prev) => 1 / prev);
+  // 화면 크기 및 회전 상태에 따라 이미지 크기 업데이트
+  useEffect(() => {
+    const updateSizes = () => {
+      if (cropContainerRef.current && imgRef.current && isImageLoaded) {
+        const containerWidth = cropContainerRef.current.clientWidth;
+        const containerHeight = cropContainerRef.current.clientHeight;
+
+        const { naturalWidth, naturalHeight } = imageSize;
+        const isRotated90or270 = Math.abs(rotation % 180) === 90;
+
+        // 회전을 고려한 이미지 크기 계산
+        const imageWidth = isRotated90or270 ? naturalHeight : naturalWidth;
+        const imageHeight = isRotated90or270 ? naturalWidth : naturalHeight;
+        const imageAspectRatio = imageWidth / imageHeight;
+
+        let width, height;
+        const containerAspectRatio = containerWidth / containerHeight;
+
+        if (imageAspectRatio > containerAspectRatio) {
+          // 이미지가 컨테이너보다 더 넓은 경우
+          width = containerWidth;
+          height = containerWidth / imageAspectRatio;
+        } else {
+          // 이미지가 컨테이너보다 더 높은 경우
+          height = containerHeight;
+          width = containerHeight * imageAspectRatio;
+        }
+
+        setImageSize((prev) => ({
+          ...prev,
+          width: Math.round(width),
+          height: Math.round(height)
+        }));
+
+        // 이미지 크기가 변경되면 크롭 영역도 업데이트
+        updateCropArea(imageAspectRatio);
+      }
+    };
+
+    if (isImageLoaded) {
+      updateSizes();
+    }
+
+    window.addEventListener('resize', updateSizes);
+    return () => window.removeEventListener('resize', updateSizes);
+  }, [
+    rotation,
+    imageSize.naturalWidth,
+    imageSize.naturalHeight,
+    isImageLoaded
+  ]);
+
+  // 크롭 영역을 업데이트하는 함수
+  const updateCropArea = (_aspectRatio: number) => {
+    const cropSize = 100; // 기본 크롭 크기 (%)
+
+    // 마지막 completedCrop 정보가 있으면 비율만 유지하면서 위치 조정
+    if (completedCrop) {
+      // 기존 크롭 영역 중심점 계산
+      const centerX = completedCrop.x + completedCrop.width / 2;
+      const centerY = completedCrop.y + completedCrop.height / 2;
+
+      // 회전에 따른 새 크기 계산 (단위는 %)
+      const newWidth = cropSize;
+      const newHeight = cropSize;
+
+      // 새로운 크롭 영역의 왼쪽 상단 좌표 계산
+      let x = Math.max(0, centerX - newWidth / 2);
+      let y = Math.max(0, centerY - newHeight / 2);
+
+      // 화면 경계를 벗어나지 않도록 조정
+      if (x + newWidth > 100) x = 100 - newWidth;
+      if (y + newHeight > 100) y = 100 - newHeight;
+
+      setCrop({
+        unit: '%',
+        width: newWidth,
+        height: newHeight,
+        x,
+        y
+      });
+    } else {
+      // 초기 설정인 경우 중앙에 배치
+      setCrop({
+        unit: '%',
+        width: 100,
+        height: 100,
+        x: 0,
+        y: 0
+      });
+    }
   };
 
-  const handleRotateRight = () => {
-    setRotation((prev) => (prev + 90) % 360);
-    setAspectRatio((prev) => 1 / prev);
+  // 크롭된 이미지를 캔버스에서 생성
+  const cropImage = () => {
+    if (!imgRef.current || !completedCrop || !previewCanvasRef.current) return;
+
+    const canvas = previewCanvasRef.current;
+    const image = imgRef.current;
+    const ctx = canvas.getContext('2d');
+
+    if (!ctx) return;
+
+    // 원본 이미지에서 크롭할 부분을 계산하기 위한 배율
+    const scaleX = imageSize.naturalWidth / image.width;
+    const scaleY = imageSize.naturalHeight / image.height;
+
+    let { x, y, width, height } = completedCrop;
+    x *= scaleX;
+    y *= scaleY;
+    width *= scaleX;
+    height *= scaleY;
+
+    // 회전 상태에 따른 크롭 좌표 보정
+    let newX = x,
+      newY = y,
+      newWidth = width,
+      newHeight = height;
+    const isRotated90or270 = Math.abs(rotation % 180) === 90;
+
+    if (rotation === 90) {
+      newX = y;
+      newY = imageSize.naturalWidth - (x + width);
+      newWidth = height;
+      newHeight = width;
+    } else if (rotation === 180) {
+      newX = imageSize.naturalWidth - (x + width);
+      newY = imageSize.naturalHeight - (y + height);
+    } else if (rotation === 270) {
+      newX = imageSize.naturalHeight - (y + height);
+      newY = x;
+      newWidth = height;
+      newHeight = width;
+    }
+
+    // 캔버스 크기 설정
+    canvas.width = isRotated90or270 ? newHeight : newWidth;
+    canvas.height = isRotated90or270 ? newWidth : newHeight;
+
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.save();
+    ctx.translate(canvas.width / 2, canvas.height / 2);
+    ctx.rotate((rotation * Math.PI) / 180);
+    ctx.scale(flipX, flipY);
+
+    const dx = -newWidth / 2;
+    const dy = -newHeight / 2;
+    ctx.drawImage(
+      image,
+      newX,
+      newY,
+      newWidth,
+      newHeight,
+      dx,
+      dy,
+      newWidth,
+      newHeight
+    );
+
+    ctx.restore();
+
+    // 크롭된 이미지를 Base64로 변환 후 전달
+    const croppedImage = canvas.toDataURL('image/png');
+    onCropComplete(croppedImage);
   };
 
-  const handleFlipX = () => setFlipX((prev) => prev * -1);
-  const handleFlipY = () => setFlipY((prev) => prev * -1);
-  const handleReset = () => {
+  useEffect(() => {
+    if (completedCrop) {
+      cropImage();
+    }
+  }, [completedCrop, rotation, flipX, flipY]);
+
+  const rotateLImage = () => {
+    const newRotation = (rotation - 90) % 360;
+    setRotation(newRotation);
+  };
+
+  const rotateRImage = () => {
+    const newRotation = (rotation + 90) % 360;
+    setRotation(newRotation);
+  };
+
+  const flipImageX = () => setFlipX((prev) => prev * -1);
+  const flipImageY = () => setFlipY((prev) => prev * -1);
+
+  const resetImage = () => {
+    setSelectedImage(originalImage);
     setRotation(0);
     setFlipX(1);
     setFlipY(1);
-    setAspectRatio(1);
     setCompletedCrop(null);
+
+    const naturalAspectRatio = imageSize.naturalWidth / imageSize.naturalHeight;
+    updateCropArea(naturalAspectRatio);
   };
+
 
   return (
     <div className="relative flex flex-col items-center w-full h-full bg-black overflow-hidden">
-      <div
-        ref={cropContainerRef}
-        className="relative flex-grow flex justify-center items-center"
-        style={{
-          transform: `rotate(${rotation}deg)`,
-          transition: 'transform 0.3s ease-in-out'
-        }}
-      >
+      {/* Header */}
+
+      <div className="flex-1 flex flex-col">
         {selectedImage && (
-          <ReactCrop
-            crop={crop}
-            onChange={(c) => setCrop(c)}
-            onComplete={(c) => setCompletedCrop(c)}
-            aspect={aspectRatio}
+          <div
+            ref={cropContainerRef}
+            className="relative flex-1 flex items-center justify-center overflow-hidden"
           >
-            <img
-              ref={imgRef}
-              src={selectedImage}
-              alt="Uploaded"
-              className="max-w-full max-h-[70vh] object-contain"
-              style={{
-                transform: `scaleX(${flipX}) scaleY(${flipY})`,
-                transition: 'transform 0.3s ease-in-out'
-              }}
-            />
-          </ReactCrop>
+            {isImageLoaded && (
+              <ReactCrop
+                crop={crop}
+                onChange={(c) => setCrop(c)}
+                onComplete={(c) => setCompletedCrop(c)}
+                className="relative z-20"
+                style={{
+                  maxHeight: '100%',
+                  maxWidth: '100%'
+                }}
+              >
+                <img
+                  ref={imgRef}
+                  src={selectedImage || '/placeholder.svg'}
+                  alt="Upload"
+                  className="object-contain"
+                  style={{
+                    width:
+                      imageSize.width > 0 ? `${imageSize.width}px` : 'auto',
+                    height:
+                      imageSize.height > 0 ? `${imageSize.height}px` : 'auto',
+                    transform: `rotate(${rotation}deg) scaleX(${flipX}) scaleY(${flipY})`,
+                    transition: 'transform 0.3s ease'
+                  }}
+                  onLoad={() => {
+                    if (imgRef.current) {
+                      const naturalAspectRatio =
+                        imageSize.naturalWidth / imageSize.naturalHeight;
+                      const isRotated90or270 = Math.abs(rotation % 180) === 90;
+                      const effectiveRatio = isRotated90or270
+                        ? 1 / naturalAspectRatio
+                        : naturalAspectRatio;
+                      updateCropArea(effectiveRatio);
+                    }
+                  }}
+                />
+              </ReactCrop>
+            )}
+          </div>
         )}
       </div>
 
-      <button
-        className="absolute bottom-[92px] w-[110px] h-[45px] whitespace-nowrap font-sm-semibold bg-warning-50 text-warning-300 px-3  rounded-[16px] flex items-center gap-2"
-        onClick={handleReset}
-      >
-        <ResetIcon color="#FF433C" />
-        원본으로
-      </button>
-
-      <div className="absolute bottom-0 w-[208px] h-[56px] bg-white px-4 py-3 rounded-[24px] flex justify-around items-center mb-[24px] gap-6">
+      <div className="flex justify-center mb-4">
         <button
-          onClick={handleRotateLeft}
-          className="flex flex-col items-center"
+          className="absolute bottom-[92px] w-[110px] h-[45px] whitespace-nowrap font-sm-semibold bg-warning-50 text-warning-300 px-3  rounded-[16px] flex items-center gap-2"
+          onClick={resetImage}
         >
-          <Rotation1 size={24} />
-        </button>
-        <button
-          onClick={handleRotateRight}
-          className="flex flex-col items-center"
-        >
-          <Rotation2 size={24} />
-        </button>
-        <button onClick={handleFlipX} className="flex flex-col items-center">
-          <Horizontal />
-        </button>
-        <button onClick={handleFlipY} className="flex flex-col items-center">
-          <Horizontal rotate={90} />
+          <ResetIcon color="#FF433C" />
+          원본으로
         </button>
       </div>
+
+      <div className="flex justify-center mb-8">
+        <div className="absolute bottom-0 w-[208px] h-[56px] bg-white px-4 py-3 rounded-[24px] flex justify-around items-center mb-[24px] gap-6">
+          <button onClick={rotateLImage} className="text-gray-500">
+            <Rotation1 size={24} />
+          </button>
+          <button onClick={rotateRImage} className="text-gray-500">
+            <Rotation2 size={24} />
+          </button>
+          <button onClick={flipImageX} className="text-gray-500">
+            <Horizontal />
+          </button>
+          <button onClick={flipImageY} className="text-gray-500">
+            <Horizontal rotate={90} />
+          </button>
+        </div>
+      </div>
+
+      <canvas ref={previewCanvasRef} style={{ display: 'none' }}></canvas>
     </div>
   );
 };

--- a/src/pages/MOBILE/uploadTax/ImageCrop.tsx
+++ b/src/pages/MOBILE/uploadTax/ImageCrop.tsx
@@ -15,12 +15,7 @@ interface ImageCropProps {
   onComplete?: () => void;
 }
 
-const ImageCrop = ({
-  initialImage,
-  onCropComplete,
-  onClose,
-  onComplete
-}: ImageCropProps) => {
+const ImageCrop = ({ initialImage, onCropComplete }: ImageCropProps) => {
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [originalImage, setOriginalImage] = useState<string | null>(null);
   const [crop, setCrop] = useState<Crop>({
@@ -266,7 +261,6 @@ const ImageCrop = ({
     const naturalAspectRatio = imageSize.naturalWidth / imageSize.naturalHeight;
     updateCropArea(naturalAspectRatio);
   };
-
 
   return (
     <div className="relative flex flex-col items-center w-full h-full bg-black overflow-hidden">

--- a/src/pages/MOBILE/uploadTax/Step1Mobile.tsx
+++ b/src/pages/MOBILE/uploadTax/Step1Mobile.tsx
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import ImageCrop from './ImageCrop';
 import api from '../../../hooks/api';
 import DuplicateTaxModal from '../../CS/TaxUpload/DuplicateTaxModal';
+import ConfirmUpload from '../../CS/TaxUpload/ConfirmUpload';
 
 const Step1Mobile = () => {
   const navigate = useNavigate();
@@ -11,6 +12,8 @@ const Step1Mobile = () => {
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [croppedImage, setCroppedImage] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState<boolean>(false);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(true);
+
   const [isDuplicateModalOpen, setIsDuplicateModalOpen] =
     useState<boolean>(false);
 
@@ -107,6 +110,14 @@ const Step1Mobile = () => {
           />
         )}
       </div>
+      {/* 처음 사진업로드 확인모달 */}
+      {isModalOpen && (
+        <ConfirmUpload
+          title="여러 장의 세금계산서는 오류가 생겨요!"
+          message="한 장만 나오도록 사진을 잘라주세요."
+          onClose={() => setIsModalOpen(false)}
+        />
+      )}
       {/* 중복일경우 모달 */}
       {isDuplicateModalOpen && (
         <DuplicateTaxModal

--- a/src/pages/MOBILE/uploadTax/Step1Mobile.tsx
+++ b/src/pages/MOBILE/uploadTax/Step1Mobile.tsx
@@ -49,7 +49,7 @@ const Step1Mobile = () => {
       const { ntsTaxId, issueId, status, title, issueDate } = res.data.result;
 
       if (issueId === '이미 등록된 세금계산서입니다.') {
-        if (status === 'APPROVED') {
+        if (status === 'APPROVE') {
           setDuplicateId(ntsTaxId.toString());
           setDuplicateTitle(title || '세금계산서');
           setDuplicateTaxDate(issueDate || '날짜 없음');
@@ -71,6 +71,7 @@ const Step1Mobile = () => {
           navigate(`/uploadTax/step2?taxId=${ntsTaxId}`, {
             state: { ocrData: res.data, selectedImage: croppedImage }
           });
+
           return;
         }
       }

--- a/src/pages/MOBILE/uploadTax/Step3Mobile.tsx
+++ b/src/pages/MOBILE/uploadTax/Step3Mobile.tsx
@@ -19,7 +19,7 @@ const Step3Mobile = () => {
         <img
           src={step3Icon}
           alt="세금계산서 검증"
-          className="w-[250px] h-[250px]"
+          className="w-[250px] h-[250px] stop-animation"
         />
         <div className="text-gray-600 font-md-medium whitespace-nowrap">
           홈택스를 통해서 검증하고 있어요

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -74,6 +74,7 @@ function LoginPage() {
           />
           <FloatingLabelInput
             placeholder="비밀번호"
+            type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
           />

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import FloatingLabelInput from './components/LabelInput';
 import RedLogo from '../../../public/Icon/RedLogoIcon';
 import Button from '../../common/Button';
@@ -38,7 +38,6 @@ function LoginPage() {
         } else {
           console.error('Access Token이 없음.');
         }
-
         const role = response.data.result?.role;
         localStorage.setItem('userRole', role);
 
@@ -60,7 +59,9 @@ function LoginPage() {
       setError('로그인 요청 중 문제가 발생했습니다. 다시 시도해 주세요.');
     }
   };
-
+  useEffect(() => {
+    fetchUserInfo();
+  }, []);
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
       <div className="w-[456px] mx-auto px-6 py-[40px] bg-white rounded-[32px] drop-shadow-elevation1 max-sm:min-h-screen flex flex-col justify-center">

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -17,7 +17,6 @@ function LoginPage() {
   const navigate = useNavigate();
   const { setAuthData, fetchUserInfo } = useAuthStore();
   const isButtonDisabled = !loginId || !password;
-
   const handleLogin = async () => {
     try {
       const response = await api.post('/auth/login', {
@@ -30,38 +29,37 @@ function LoginPage() {
       if (response.data) {
         const accessToken =
           response.headers['authorization']?.split('Bearer ')[1];
-        setAuthData(accessToken);
-        await fetchUserInfo();
+
         if (accessToken) {
           localStorage.setItem('accessToken', accessToken);
-          console.log('Access Token 저장', accessToken);
+
+          await setAuthData(accessToken);
+          await fetchUserInfo();
         } else {
-          console.error('Access Token이 없음.');
+          console.error(' Access Token이 없음.');
+          setError('인증 토큰이 없습니다. 다시 로그인해 주세요.');
+          return;
         }
+
         const role = response.data.result?.role;
         localStorage.setItem('userRole', role);
 
-        console.log(role);
         if (role === 'CS_USER') {
-          //대리점
           navigate('/cs');
         } else if (role === 'HQ_USER') {
-          //본사
           navigate('/hq');
         } else {
-          //관리자
           navigate('/admin');
         }
       } else {
         setError('아이디 또는 비밀번호가 잘못되었습니다.');
       }
     } catch (error) {
+      console.error(' 로그인 요청 실패:', error);
       setError('로그인 요청 중 문제가 발생했습니다. 다시 시도해 주세요.');
     }
   };
-  useEffect(() => {
-    fetchUserInfo();
-  }, []);
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
       <div className="w-[456px] mx-auto px-6 py-[40px] bg-white rounded-[32px] drop-shadow-elevation1 max-sm:min-h-screen flex flex-col justify-center">

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -43,13 +43,13 @@ function LoginPage() {
         console.log(role);
         if (role === 'CS_USER') {
           //대리점
-          navigate('/CS-home');
+          navigate('/cs');
         } else if (role === 'HQ_USER') {
           //본사
-          navigate('/HQ-home');
+          navigate('/hq');
         } else {
           //관리자
-          navigate('/');
+          navigate('/admin');
         }
       } else {
         setError('아이디 또는 비밀번호가 잘못되었습니다.');

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import {  useState } from 'react';
 import FloatingLabelInput from './components/LabelInput';
 import RedLogo from '../../../public/Icon/RedLogoIcon';
 import Button from '../../common/Button';

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,4 +1,4 @@
-import {  useState } from 'react';
+import { useState } from 'react';
 import FloatingLabelInput from './components/LabelInput';
 import RedLogo from '../../../public/Icon/RedLogoIcon';
 import Button from '../../common/Button';
@@ -45,11 +45,11 @@ function LoginPage() {
         localStorage.setItem('userRole', role);
 
         if (role === 'CS_USER') {
-          navigate('/cs');
+          navigate('/cs/home');
         } else if (role === 'HQ_USER') {
-          navigate('/hq');
+          navigate('/hq/home');
         } else {
-          navigate('/admin');
+          navigate('/admin/home');
         }
       } else {
         setError('아이디 또는 비밀번호가 잘못되었습니다.');

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -7,6 +7,7 @@ import LoginFooter from './components/LoginFooter';
 import ApprovalModal from './components/ApprovalModal';
 import api from '../../hooks/api';
 import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../../store/useAuthStore';
 
 function LoginPage() {
   const [loginId, setLoginId] = useState('');
@@ -14,7 +15,7 @@ function LoginPage() {
   const [error, setError] = useState('');
   const [isApprovalModalOpen, setIsApprovalModalOpen] = useState(false);
   const navigate = useNavigate();
-
+  const { setAuthData, fetchUserInfo } = useAuthStore();
   const isButtonDisabled = !loginId || !password;
 
   const handleLogin = async () => {
@@ -29,7 +30,8 @@ function LoginPage() {
       if (response.data) {
         const accessToken =
           response.headers['authorization']?.split('Bearer ')[1];
-
+        setAuthData(accessToken);
+        await fetchUserInfo();
         if (accessToken) {
           localStorage.setItem('accessToken', accessToken);
           console.log('Access Token 저장', accessToken);

--- a/src/routes/MobileRouter.tsx
+++ b/src/routes/MobileRouter.tsx
@@ -13,7 +13,7 @@ const MobileRouter = createBrowserRouter([
   { path: '/uploadTax/step2', element: <Step2Mobile /> },
   { path: '/uploadTax/step3/checking', element: <Step3Mobile /> },
   { path: '/complete', element: <Complete /> },
-  { path: '/Home', element: <Home /> }
+  { path: '/cs', element: <Home /> }
 ]);
 
 export default MobileRouter;

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,0 +1,49 @@
+import { create } from 'zustand';
+import api from '../hooks/api';
+
+interface User {
+  name: string;
+  teamName: string;
+}
+
+interface AuthState {
+  accessToken: string | null;
+  user: User | null;
+  setAuthData: (token: string) => void;
+  fetchUserInfo: () => Promise<void>;
+  clearAuthData: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  accessToken: localStorage.getItem('accessToken') || null,
+  user: null,
+
+  setAuthData: (token) => {
+    localStorage.setItem('accessToken', token);
+    set({ accessToken: token });
+  },
+
+  fetchUserInfo: async () => {
+    try {
+      console.log('✅ 유저 정보 조회 시작...');
+      const response = await api.get('/user/detail');
+      console.log('📩 응답 데이터:', response.data);
+
+      if (response.data.isSuccess && response.data.result) {
+        const { name, teamName } = response.data.result;
+        set({ user: { name, teamName } });
+        console.log('✅ Zustand 상태 업데이트 완료:', { name, teamName });
+      } else {
+        console.error('❌ 유저 정보 가져오기 실패:', response.data.message);
+      }
+    } catch (error) {
+      console.error('❌ 유저 정보 가져오기 실패', error);
+    }
+  },
+
+  clearAuthData: () => {
+    localStorage.removeItem('accessToken');
+    set({ accessToken: null, user: null });
+    console.log('🚫 상태 초기화 완료');
+  }
+}));

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -17,28 +17,26 @@ interface AuthState {
 
 export const useAuthStore = create<AuthState>()(
   persist(
-    (set, get) => ({
+    (set) => ({
       accessToken: null,
       user: null,
 
       setAuthData: (token) => {
-        console.log('✅ 액세스 토큰 저장:', token);
         set({ accessToken: token });
       },
 
       fetchUserInfo: async () => {
         try {
-          console.log('✅ 유저 정보 조회 시작...');
           const response = await api.get('/user/detail');
-          console.log('📩 응답 데이터:', response.data);
+          console.log(' 응답 데이터:', response.data);
 
           if (response.data.isSuccess && response.data.result) {
             const { name, teamName } = response.data.result;
             set({ user: { name, teamName } });
-            console.log('✅ Zustand 상태 업데이트 완료:', { name, teamName });
+            console.log('Zustand 상태 업데이트 ', { name, teamName });
 
           } else {
-            console.error('❌ 유저 정보 가져오기 실패:', response.data.message);
+            console.error( response.data.message);
           }
         } catch (error) {
           console.error('❌ 유저 정보 가져오기 실패', error);
@@ -47,12 +45,12 @@ export const useAuthStore = create<AuthState>()(
 
       clearAuthData: () => {
         set({ accessToken: null, user: null });
-        console.log('🚫 상태 초기화 완료');
+        console.log('상태 초기화');
       }
     }),
     {
-      name: 'auth-storage', // ✅ localStorage에 저장되는 키 이름
-      storage: createJSONStorage(() => localStorage) // ✅ localStorage 저장
+      name: 'auth-storage', 
+      storage: createJSONStorage(() => localStorage) 
     }
   )
 );


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## ✈️ 이슈 번호
close #87  

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- 모바일에서 imagecrop문제 해결했고 모바일의 홈 , 중복처리 완료했습니다.
- 중복모달에서 확인누르면 세금계산서 모바일페이지로 가야하는데 일단 기획과 상의로 홈으로 다시 보내도록 했습니다
- password type설정했고 로그인시 store에 저장해서 sidebar, 세팅아이콘으로 사이드모달에서도 조회가능합니다.
- 세팅아이콘-> 사이드모달에서 수정요청은 아직 수정api 가 백엔드랑 해결되지 않아서 미완입니다..ㅎㅎ 


## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.
![image](https://github.com/user-attachments/assets/33d80f16-6c55-4b23-9290-bc011d5599ff)
![image](https://github.com/user-attachments/assets/25e9ab02-5212-4d67-8694-ef9cce2dbac1)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.